### PR TITLE
test(tests): add builder kitchen sink end-to-end tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  NEXTEST_NO_TESTS: warn
 
 jobs:
   format:
@@ -31,7 +30,10 @@ jobs:
           cache: false
           rustflags: ''
 
-      - run: cargo +nightly fmt --all -- --check
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - run: just fmt-check
 
   test:
     runs-on: ubuntu-latest
@@ -47,8 +49,8 @@ jobs:
           cache: true
           rustflags: ''
 
-      - name: Cache rust build files
-        uses: Leafwing-Studios/cargo-cache@43ec9a5bad6e7f174e7fc65dcf533de75ff65881 # v2
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
 
       - name: Install Cargo LLVM cov
         uses: baptiste0928/cargo-install@b687c656bda5733207e629b50a22bf68974a0305 # v3
@@ -62,36 +64,88 @@ jobs:
           version: ^0.9
 
       ## Linting
-      - name: Cargo clippy
-        run: cargo clippy --all-features --tests -- -D warnings --force-warn deprecated --force-warn dead-code
+      - run: just clippy
 
       ## Tests
       - name: Unit tests
-        run: cargo llvm-cov nextest --all-features 'tests::' --lcov --output-path unit-lcov.info -- --skip 'tests::it_'
+        run: just test-unit-cov
 
       - name: Doc tests
         # TODO: Collect doc tests coverage once nextest supports it
         # https://nexte.st/docs/integrations/test-coverage/?h=doc#collecting-coverage-data-from-doctests
-        run: cargo test --all-features --doc
+        run: just test-doc
 
       - name: Integration tests (in-tree)
-        run: cargo llvm-cov nextest --all-features 'tests::it_' --lcov --output-path it-intree-lcov.info
+        run: just test-it-intree-cov
 
-      - name: Integration tests (public api)
-        run: cargo llvm-cov nextest --all-features --test '*' --lcov --output-path it-public-lcov.info
+      - name: Integration tests (public API)
+        run: just test-it-public-cov
+
+      - name: E2E tests
+        run: just test-e2e-cov
 
       - name: Upload unit tests coverage report to codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: unit-lcov.info
+          files: target/lcov/unit-lcov.info
           flags: unit
 
-      - name: Upload integration tests coverage report to codecov
+      - name: Upload integration tests (in-tree) coverage report to codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: it-intree-lcov.info,it-public-lcov.info
-          flags: integration
+          files: target/lcov/it-intree-lcov.info
+          flags: integration-intree
+
+      - name: Upload integration tests (public API) coverage report to codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: target/lcov/it-public-lcov.info
+          flags: integration-public
+
+      - name: Upload E2E tests coverage report to codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: target/lcov/e2e-lcov.info
+          flags: e2e
+
+  # Check generated code is up to date
+  gen-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
+        with:
+          cache: true
+          rustflags: ''
+
+      - name: Install just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - run: just gen
+
+      - name: Check for uncommitted changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            printf "❌ Generated code is out of date. Please run 'just gen' and commit the changes.\n"
+
+            printf "\n📄 Files with changes:\n"
+            git status --porcelain
+
+            printf "\n🔍 Detailed diff:\n"
+            git diff --color=always
+
+            exit 1
+          else
+            printf "✅ Generated code is up to date.\n"
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,1000 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -33,10 +1017,240 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9c261f7ce75418b3beadfb3f0eb1299fe8eb9640deba45ffa2cb783098697d"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -82,6 +1296,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,14 +1378,236 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "tests"
 version = "0.0.0"
+dependencies = [
+ "insta",
+ "jsonschema",
+ "reqwest",
+ "serde_json",
+ "serde_norway",
+ "utocli",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+ "socket2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utocli"
@@ -115,4 +1622,406 @@ version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,8 @@ future-incompatible = { level = "deny", priority = -1 }
 nonstandard-style = { level = "deny", priority = -1 }
 unused = { level = "deny", priority = -1 }
 
+# Allow the fetch_opencli_schema cfg flag used for conditional OpenCLI spec download
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fetch_opencli_schema)'] }
+
 [workspace.lints.clippy]
 all = "deny"

--- a/nextest.toml
+++ b/nextest.toml
@@ -1,0 +1,41 @@
+# Nextest configuration for utocli workspace
+# See: https://nexte.st/docs/configuration/
+#
+# Test Organization (Four-Tier Strategy):
+# 1. Unit tests: #[cfg(test)] mod tests within src/ (no 'it_' submodule prefix)
+# 2. In-tree integration: #[cfg(test)] mod tests::it_* within src/ (has 'it_' submodule)
+# 3. Public API integration: <crate>/tests/ directory (can use it_*.rs naming)
+# 4. E2E tests: Workspace-level 'tests' crate
+#
+# Key insight: In-tree vs Public API differentiation is by LOCATION not naming.
+# - In-tree: Within src/ as #[cfg(test)] modules (kind(lib) or kind(bin))
+# - Public API: In <crate>/tests/ directories (kind(test))
+
+[profile.default]
+fail-fast = false
+
+# Unit tests: Tests within src/ in 'tests::' modules, excluding 'it_*' submodules
+# Location: src/ files with #[cfg(test)] mod tests { ... }
+# Filter: Not from tests crate, not integration test binary, not it_* submodule
+[profile.unit]
+default-filter = 'not package(tests) and not kind(test) and not binary(/it_/)'
+
+# In-tree integration tests: Tests within src/ in 'tests::it_*' submodules
+# Location: src/ files with #[cfg(test)] mod tests { mod it_* { ... } }
+# Filter: Has it_* in binary name, not integration test binary, not tests crate
+# Note: Both lib and bin crates can have in-tree integration tests
+[profile.it-intree]
+default-filter = 'binary(/it_/) and not kind(test) and not package(tests)'
+
+# Public API integration tests: Tests in <crate>/tests/ directories
+# Location: <crate>/tests/*.rs (e.g., crates/utocli/tests/it_api.rs)
+# Filter: Integration test binary (kind(test)), not from workspace tests crate
+# Note: Files can be named it_*.rs - the location differentiates from in-tree tests
+[profile.it-public]
+default-filter = 'kind(test) and not package(tests)'
+
+# E2E tests: Tests in the workspace-level 'tests' crate only
+# Location: <workspace-root>/tests/tests/*.rs (the separate 'tests' package)
+# Filter: Only tests from the 'tests' package
+[profile.e2e]
+default-filter = 'package(tests)'

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,6 +4,14 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+utocli = { path = "../crates/utocli" }
+insta = { version = "1.39", features = ["json", "yaml"] }
+jsonschema = "0.33.0"
+serde_json = "1.0"
+serde_norway = "0.9"
+
+[build-dependencies]
+reqwest = { version = "0.12", features = ["blocking"] }
 
 [lints]
 workspace = true

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,0 +1,57 @@
+//! Build script for downloading the OpenCLI specification schema.
+//!
+//! When the `fetch_opencli_schema` cfg flag is enabled, this script downloads
+//! the latest OpenCLI spec from GitHub and saves it to `tests/assets/opencli.spec.json`.
+
+fn main() {
+    #[cfg(not(fetch_opencli_schema))]
+    {
+        println!(
+            "cargo:debug=Config 'fetch_opencli_schema' not enabled: Skipping OpenCLI spec download"
+        );
+    }
+    #[cfg(fetch_opencli_schema)]
+    {
+        /// The URL to the OpenCLI spec file (main branch)
+        const SPEC_URL: &str = "https://raw.githubusercontent.com/nrranjithnr/open-cli-specification/refs/heads/main/opencli.spec.json";
+
+        /// The path to the OpenCLI spec file
+        const SPEC_PATH: &str = "tests/assets/opencli.spec.json";
+
+        println!("cargo:warning=Config 'fetch_opencli_schema' enabled: Downloading OpenCLI spec");
+
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+            .map(std::path::PathBuf::from)
+            .expect("Failed to get CARGO_MANIFEST_DIR");
+
+        let spec_path = manifest_dir.join(SPEC_PATH);
+
+        // Create the assets directory if it doesn't exist
+        if let Some(parent) = spec_path.parent() {
+            std::fs::create_dir_all(parent).expect("Failed to create assets directory");
+        }
+
+        // Download the spec file using reqwest
+        let client = reqwest::blocking::Client::new();
+        let response = client
+            .get(SPEC_URL)
+            .send()
+            .expect("Failed to download OpenCLI spec");
+
+        if !response.status().is_success() {
+            panic!(
+                "Failed to download opencli.spec.json file: {}",
+                response.status()
+            );
+        }
+
+        let content = response
+            .text()
+            .expect("Failed to read OpenCLI spec response body");
+
+        // Write the content to the file
+        std::fs::write(&spec_path, content).expect("Failed to write opencli.spec.json to file");
+
+        println!("cargo:warning=Downloaded latest version of opencli.spec.json from GitHub");
+    }
+}

--- a/tests/tests/assets/opencli.spec.json
+++ b/tests/tests/assets/opencli.spec.json
@@ -1,0 +1,445 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.openclispec.org/schema/v1.0.0",
+  "title": "OpenCLI Specification",
+  "description": "The OpenCLI Specification v1.0.0 - A standardized specification for defining command-line interfaces",
+  "type": "object",
+  "required": ["opencli", "info", "commands"],
+  "additionalProperties": false,
+  "properties": {
+    "opencli": {
+      "description": "Specifies which version of the OpenCLI specification your CLI tool follows. Always place this as the first field in your YAML file.",
+      "const": "1.0.0"
+    },
+    "info": {
+      "type": "object",
+      "description": "Core metadata that identifies your CLI tool to users and package managers.",
+      "required": ["title", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Human-readable name of your CLI application (used in help text and documentation).",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief explanation of what your CLI tool does (appears in --help output)."
+        },
+        "version": {
+          "type": "string",
+          "description": "Current version following semantic versioning (major.minor.patch).",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$"
+        },
+        "contact": {
+          "type": "object",
+          "description": "How users can reach you for support, bug reports, or contributions.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Maintainer name or organization responsible for the CLI tool."
+            },
+            "url": {
+              "type": "string",
+              "description": "Primary support channel (GitHub issues, website, etc.).",
+              "format": "uri"
+            },
+            "email": {
+              "type": "string",
+              "description": "Direct email for urgent issues or security reports.",
+              "format": "email"
+            }
+          }
+        },
+        "license": {
+          "type": "object",
+          "description": "Legal terms under which your CLI tool is distributed.",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "SPDX license identifier (e.g., MIT, Apache-2.0, GPL-3.0)."
+            },
+            "url": {
+              "type": "string",
+              "description": "Full license text location for legal compliance.",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    },
+    "externalDocs": {
+      "type": "object",
+      "description": "Links to comprehensive guides, tutorials, and API documentation.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Brief summary of what the external documentation contains."
+        },
+        "url": {
+          "type": "string",
+          "description": "Direct link to comprehensive guides and documentation.",
+          "format": "uri"
+        }
+      }
+    },
+    "platforms": {
+      "type": "array",
+      "description": "OS-specific configurations for Windows, macOS, and Linux distributions.",
+      "items": {
+        "$ref": "#/definitions/Platform"
+      }
+    },
+    "environment": {
+      "type": "array",
+      "description": "Maps environment variables to CLI parameters for containerized deployments.",
+      "items": {
+        "$ref": "#/definitions/EnvironmentVariable"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "description": "Logical grouping system for organizing commands by feature or domain.",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
+    },
+    "commands": {
+      "type": "object",
+      "description": "Hierarchical structure defining all available CLI commands and subcommands.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/Command"
+      }
+    },
+    "components": {
+      "type": "object",
+      "description": "Reusable components for the specification.",
+      "additionalProperties": false,
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "description": "Reusable data schemas for validation.",
+          "additionalProperties": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Reusable parameter definitions.",
+          "additionalProperties": {
+            "$ref": "#/definitions/Parameter"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "description": "Reusable response definitions.",
+          "additionalProperties": {
+            "$ref": "#/definitions/Response"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Platform": {
+      "type": "object",
+      "description": "Platform and architecture information.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operating system identifier (linux, macos, windows, etc.).",
+          "enum": ["windows", "macos", "darwin", "ios", "linux", "android", "freebsd", "dragonfly", "openbsd", "netbsd", "aix", "solaris"]
+        },
+        "architectures": {
+          "type": "array",
+          "description": "Supported CPU architectures for this platform.",
+          "items": {
+            "type": "string",
+            "enum": ["amd64", "x86_64", "386", "x86", "arm64", "aarch64", "arm", "armv5te", "armv7", "thumbv7", "ppc64", "ppc64le", "powerpc", "powerpc64", "powerpc64le", "mips", "mipsel", "mips64", "mips64el", "s390x", "riscv64", "riscv32", "wasm32", "wasm64", "sparc64", "hexagon", "loongarch64"]
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "EnvironmentVariable": {
+      "type": "object",
+      "description": "Environment variable definition.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Environment variable name that your CLI tool recognizes.",
+          "pattern": "^[A-Z][A-Z0-9_]*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Purpose and usage of this environment variable."
+        }
+      }
+    },
+    "Tag": {
+      "type": "object",
+      "description": "Tag for grouping and organizing commands.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for organizing related commands.",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable explanation of what commands share this tag."
+        }
+      }
+    },
+    "Command": {
+      "type": "object",
+      "description": "Command definition with metadata, parameters, and responses.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "description": "Extension property (vendor-specific metadata)"
+        }
+      },
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "One-line description shown in command help listings."
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed explanation of command purpose and behavior."
+        },
+        "operationId": {
+          "type": "string",
+          "description": "Unique identifier for programmatic access (for testing, docs, etc.).",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "aliases": {
+          "type": "array",
+          "description": "Alternative command names for user convenience.",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "description": "Categories for organizing commands in help and documentation.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "description": "All flags, options, and arguments this command accepts.",
+          "items": {
+            "$ref": "#/definitions/Parameter"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "description": "Exit codes and output formats users can expect.",
+          "additionalProperties": {
+            "$ref": "#/definitions/Response"
+          }
+        }
+      }
+    },
+    "Parameter": {
+      "type": "object",
+      "description": "Parameter, flag, or argument definition.",
+      "required": ["name"],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "description": "Extension property (vendor-specific metadata)"
+        }
+      },
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the parameter within the command.",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "in": {
+          "type": "string",
+          "description": "Where the parameter appears (argument for positional, flag for boolean, option for named).",
+          "enum": ["argument", "flag", "option"]
+        },
+        "position": {
+          "type": "integer",
+          "description": "Order position for positional arguments (starting from 1).",
+          "minimum": 1
+        },
+        "alias": {
+          "type": "array",
+          "description": "Short form alternatives (e.g., -v for --verbose).",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9_-]+$"
+          }
+        },
+        "description": {
+          "type": "string",
+          "description": "Help text shown to users explaining the parameter purpose."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether users must provide this parameter.",
+          "default": false
+        },
+        "scope": {
+          "type": "string",
+          "description": "Inheritance behavior - local (this command only) or inherited (available to subcommands).",
+          "enum": ["local", "inherited"],
+          "default": "local"
+        },
+        "arity": {
+          "type": "object",
+          "description": "How many values this parameter accepts (useful for arrays and lists).",
+          "additionalProperties": false,
+          "properties": {
+            "min": {
+              "type": "integer",
+              "description": "Minimum number of values required.",
+              "minimum": 0
+            },
+            "max": {
+              "type": "integer",
+              "description": "Maximum number of values allowed.",
+              "minimum": 1
+            }
+          }
+        },
+        "schema": {
+          "$ref": "#/definitions/Schema",
+          "description": "Data type, validation rules, and constraints for parameter values."
+        }
+      }
+    },
+    "Schema": {
+      "type": "object",
+      "description": "Schema definition for parameter or response validation.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Data type for validation (string, integer, boolean, array, object).",
+          "enum": ["string", "integer", "number", "boolean", "array", "object"]
+        },
+        "format": {
+          "type": "string",
+          "description": "Format hint for specialized string types (path, email, uri, date).",
+          "enum": ["path", "email", "uri", "url", "date", "date-time", "time", "uuid", "ipv4", "ipv6", "hostname", "int32", "int64", "float", "double"]
+        },
+        "enum": {
+          "type": "array",
+          "description": "Restricted list of allowed values for this parameter.",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "integer" },
+              { "type": "number" },
+              { "type": "boolean" }
+            ]
+          },
+          "minItems": 1
+        },
+        "default": {
+          "description": "Value used when parameter is not provided by the user."
+        },
+        "example": {
+          "description": "Sample value shown in help text and documentation."
+        },
+        "items": {
+          "$ref": "#/definitions/Schema",
+          "description": "Schema for array items when type is 'array'."
+        },
+        "properties": {
+          "type": "object",
+          "description": "Property schemas when type is 'object'.",
+          "additionalProperties": {
+            "$ref": "#/definitions/Schema"
+          }
+        },
+        "required": {
+          "type": "array",
+          "description": "Required property names when type is 'object'.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "minimum": {
+          "type": "number",
+          "description": "Minimum value for numeric types."
+        },
+        "maximum": {
+          "type": "number",
+          "description": "Maximum value for numeric types."
+        },
+        "minLength": {
+          "type": "integer",
+          "description": "Minimum length for string types.",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "description": "Maximum length for string types.",
+          "minimum": 0
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regular expression pattern for string validation.",
+          "format": "regex"
+        },
+        "$ref": {
+          "type": "string",
+          "description": "Reference to a reusable component schema.",
+          "pattern": "^#/components/schemas/[a-zA-Z0-9_-]+$"
+        }
+      }
+    },
+    "Response": {
+      "type": "object",
+      "description": "Response definition for a specific exit code.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable explanation of when this response occurs."
+        },
+        "content": {
+          "type": "object",
+          "description": "Output format examples by media type (text/plain, application/json, etc.).",
+          "additionalProperties": {
+            "$ref": "#/definitions/MediaType"
+          }
+        }
+      }
+    },
+    "MediaType": {
+      "type": "object",
+      "description": "Media type specific response content.",
+      "additionalProperties": false,
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Schema",
+          "description": "Schema definition for the response content."
+        },
+        "example": {
+          "description": "Example response content for this media type."
+        }
+      }
+    }
+  }
+}

--- a/tests/tests/it_build_kitchen_sink.rs
+++ b/tests/tests/it_build_kitchen_sink.rs
@@ -1,0 +1,939 @@
+//! Integration tests for building the OpenCLI kitchen-sink example.
+//!
+//! This test suite builds a comprehensive OpenCLI specification using the builder API,
+//! based on the official OpenCLI specification example.
+
+use std::collections::BTreeMap;
+
+use utocli::*;
+
+#[test]
+fn build_opencli_with_complete_spec_succeeds() {
+    //* Given
+    let info = build_info();
+    let external_docs = build_external_docs();
+    let platforms = build_platforms();
+    let environment = build_environment_variables();
+    let tags = build_tags();
+    let components = build_components();
+    let commands = build_commands();
+
+    //* When
+    let opencli = OpenCli::new(info)
+        .commands(commands)
+        .components(components)
+        .tags(tags)
+        .platforms(platforms)
+        .environment(environment)
+        .external_docs(external_docs);
+    let json_output =
+        serde_json::to_string_pretty(&opencli).expect("should serialize OpenCLI to JSON");
+
+    //* Then
+    // Validate against the OpenCLI JSON schema
+    let value = serde_json::from_str(&json_output).expect("should parse generated JSON");
+    assert_is_schema_compliant(&value);
+
+    // Check against the stored snapshot
+    insta::assert_snapshot!(json_output);
+}
+
+#[test]
+fn serialize_opencli_to_yaml_succeeds() {
+    //* Given
+    let info = build_info();
+    let external_docs = build_external_docs();
+    let platforms = build_platforms();
+    let environment = build_environment_variables();
+    let tags = build_tags();
+    let components = build_components();
+    let commands = build_commands();
+
+    //* When
+    let opencli = OpenCli::new(info)
+        .commands(commands)
+        .components(components)
+        .tags(tags)
+        .platforms(platforms)
+        .environment(environment)
+        .external_docs(external_docs);
+    let yaml_output = serde_norway::to_string(&opencli).expect("should serialize OpenCLI to YAML");
+
+    //* Then
+    // Check against the stored snapshot
+    insta::assert_snapshot!(yaml_output);
+}
+
+/// Builds the Info section with contact and license information.
+fn build_info() -> Info {
+    Info::new("Open Command-Line Interface Specification", "1.0.0")
+        .description("Standard for defining command-line interfaces")
+        .contact(
+            Contact::new()
+                .name("OpenCLI Working Group")
+                .url("https://github.com/nrranjithnr/open-cli-specification"),
+        )
+        .license(License::new("Apache 2.0").url("https://www.apache.org/licenses/LICENSE-2.0"))
+}
+
+/// Builds the external documentation reference.
+fn build_external_docs() -> ExternalDocs {
+    ExternalDocs::new("https://www.openclispec.org").description("Find out more about OpenCLI")
+}
+
+/// Builds platform support definitions.
+fn build_platforms() -> Vec<Platform> {
+    vec![
+        Platform::new(PlatformName::Linux)
+            .architectures(vec![Architecture::Amd64, Architecture::Arm64]),
+        Platform::new(PlatformName::Darwin)
+            .architectures(vec![Architecture::Amd64, Architecture::Arm64]),
+        Platform::new(PlatformName::Windows)
+            .architectures(vec![Architecture::Amd64, Architecture::Arm64]),
+    ]
+}
+
+/// Builds environment variable definitions.
+fn build_environment_variables() -> Vec<EnvironmentVariable> {
+    vec![
+        EnvironmentVariable::new("OCS_CONFIG_PATH")
+            .description("Override default configuration file path"),
+        EnvironmentVariable::new("OCS_VERBOSE").description("Enable verbose output globally"),
+        EnvironmentVariable::new("OCS_QUIET").description("Suppress non-essential output globally"),
+    ]
+}
+
+/// Builds tag definitions for command organization.
+fn build_tags() -> Vec<Tag> {
+    vec![
+        Tag::new("core").description("Core commands and utilities"),
+        Tag::new("data").description("Data processing commands"),
+        Tag::new("auth").description("Authentication and user management"),
+        Tag::new("system").description("System-level commands and utilities"),
+    ]
+}
+
+/// Builds the components section with reusable schemas.
+fn build_components() -> Components {
+    let mut schemas = BTreeMap::new();
+
+    // Error schema
+    let error_schema = Schema::Object(Box::new(
+        Object::new()
+            .schema_type(SchemaType::Object)
+            .properties({
+                let mut props = BTreeMap::new();
+                props.insert(
+                    "code".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new()
+                            .schema_type(SchemaType::Integer)
+                            .format(SchemaFormat::Int32),
+                    ))),
+                );
+                props.insert(
+                    "message".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props.insert(
+                    "details".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props
+            })
+            .required(vec!["code".to_string(), "message".to_string()]),
+    ));
+    schemas.insert("Error".to_string(), RefOr::T(error_schema));
+
+    // ValidationError schema
+    let validation_error_schema = Schema::Object(Box::new(
+        Object::new()
+            .schema_type(SchemaType::Object)
+            .properties({
+                let mut props = BTreeMap::new();
+                props.insert(
+                    "line".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::Integer),
+                    ))),
+                );
+                props.insert(
+                    "message".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props.insert(
+                    "severity".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new()
+                            .schema_type(SchemaType::String)
+                            .enum_values(vec![
+                                serde_json::Value::String("error".to_string()),
+                                serde_json::Value::String("warning".to_string()),
+                            ]),
+                    ))),
+                );
+                props
+            })
+            .required(vec![
+                "line".to_string(),
+                "message".to_string(),
+                "severity".to_string(),
+            ]),
+    ));
+    schemas.insert(
+        "ValidationError".to_string(),
+        RefOr::T(validation_error_schema),
+    );
+
+    // ValidationResult schema
+    let validation_result_schema = Schema::Object(Box::new(
+        Object::new().schema_type(SchemaType::Object).properties({
+            let mut props = BTreeMap::new();
+            props.insert(
+                "valid".to_string(),
+                RefOr::T(Schema::Object(Box::new(
+                    Object::new().schema_type(SchemaType::Boolean),
+                ))),
+            );
+            props.insert(
+                "file".to_string(),
+                RefOr::T(Schema::Object(Box::new(
+                    Object::new().schema_type(SchemaType::String),
+                ))),
+            );
+            props.insert(
+                "errors".to_string(),
+                RefOr::T(Schema::Array(Array::new().items(RefOr::Ref(Ref {
+                    ref_path: "#/components/schemas/ValidationError".to_string(),
+                })))),
+            );
+            props.insert(
+                "warnings".to_string(),
+                RefOr::T(Schema::Array(Array::new().items(RefOr::T(Schema::Object(
+                    Box::new(Object::new().schema_type(SchemaType::String)),
+                ))))),
+            );
+            props
+        }),
+    ));
+    schemas.insert(
+        "ValidationResult".to_string(),
+        RefOr::T(validation_result_schema),
+    );
+
+    // GeneratedFile schema
+    let generated_file_schema = Schema::Object(Box::new(
+        Object::new()
+            .schema_type(SchemaType::Object)
+            .properties({
+                let mut props = BTreeMap::new();
+                props.insert(
+                    "path".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props.insert(
+                    "size".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::Integer),
+                    ))),
+                );
+                props.insert(
+                    "type".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props
+            })
+            .required(vec!["path".to_string(), "type".to_string()]),
+    ));
+    schemas.insert("GeneratedFile".to_string(), RefOr::T(generated_file_schema));
+
+    // GenerationResult schema
+    let generation_result_schema = Schema::Object(Box::new(
+        Object::new()
+            .schema_type(SchemaType::Object)
+            .properties({
+                let mut props = BTreeMap::new();
+                props.insert(
+                    "success".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::Boolean),
+                    ))),
+                );
+                props.insert(
+                    "output_directory".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props.insert(
+                    "language".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props.insert(
+                    "template".to_string(),
+                    RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::String),
+                    ))),
+                );
+                props.insert(
+                    "files_generated".to_string(),
+                    RefOr::T(Schema::Array(Array::new().items(RefOr::Ref(Ref {
+                        ref_path: "#/components/schemas/GeneratedFile".to_string(),
+                    })))),
+                );
+                props
+            })
+            .required(vec!["success".to_string(), "output_directory".to_string()]),
+    ));
+    schemas.insert(
+        "GenerationResult".to_string(),
+        RefOr::T(generation_result_schema),
+    );
+
+    Components::new().schemas(schemas)
+}
+
+/// Builds all commands for the CLI.
+fn build_commands() -> Commands {
+    let mut commands = Commands::new();
+    commands.insert("ocs".to_string(), build_root_command());
+    commands.insert("/validate".to_string(), build_validate_command());
+    commands.insert("/generate".to_string(), build_generate_command());
+    commands.insert("/lint".to_string(), build_lint_command());
+    commands
+}
+
+/// Builds the root 'ocs' command.
+fn build_root_command() -> Command {
+    Command::new()
+        .summary("Open CLI Spec tool")
+        .description("Main entry point for the Open CLI Specification tool")
+        .operation_id("rootCommand")
+        .aliases(vec!["opencli".to_string()])
+        .tags(vec!["core".to_string()])
+        .parameters(build_root_command_parameters())
+        .responses(build_root_command_responses())
+}
+
+/// Builds parameters for the root command.
+fn build_root_command_parameters() -> Vec<Parameter> {
+    vec![
+        Parameter::new("config")
+            .alias(vec!["c".to_string()])
+            .description("Path to configuration file")
+            .scope(ParameterScope::Inherited)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .format(SchemaFormat::Path)
+                    .example(serde_json::Value::String(
+                        "~/.config/ocs/config.yaml".to_string(),
+                    )),
+            )))),
+        Parameter::new_flag("verbose")
+            .alias(vec!["v".to_string()])
+            .description("Enable verbose output")
+            .scope(ParameterScope::Inherited)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::Boolean)
+                    .default_value(serde_json::Value::Bool(false)),
+            )))),
+        Parameter::new_flag("quiet")
+            .alias(vec!["q".to_string()])
+            .description("Suppress non-essential output")
+            .scope(ParameterScope::Inherited)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::Boolean)
+                    .default_value(serde_json::Value::Bool(false)),
+            )))),
+        Parameter::new_flag("version")
+            .alias(vec!["V".to_string()])
+            .description("Show CLI version")
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new().schema_type(SchemaType::Boolean),
+            )))),
+        Parameter::new_flag("help")
+            .alias(vec!["h".to_string()])
+            .description("Show help information")
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new().schema_type(SchemaType::Boolean),
+            )))),
+    ]
+}
+
+/// Builds responses for the root command.
+fn build_root_command_responses() -> BTreeMap<String, Response> {
+    let mut responses = BTreeMap::new();
+    responses.insert(
+        "0".to_string(),
+        Response::new()
+            .description("Version information displayed")
+            .content({
+                let mut content = BTreeMap::new();
+                content.insert(
+                    "text/plain".to_string(),
+                    MediaType::new().example(serde_json::Value::String(
+                        "ocs v1.0.0\nOpenCLI Specification v1.0.0\nPlatform: linux-amd64\n\nUsage: ocs [command] [flags]\n\nAvailable Commands:\n  validate    Validate CLI specification files\n  generate    Generate CLI code from specification\n  lint        Lint CLI specification files\n  \nUse \"ocs [command] --help\" for more information about a command.\n"
+                            .to_string(),
+                    )),
+                );
+                content.insert(
+                    "application/json".to_string(),
+                    MediaType::new()
+                        .schema(RefOr::T(Schema::Object(Box::new(
+                            Object::new().schema_type(SchemaType::Object).properties({
+                                let mut props = BTreeMap::new();
+                                props.insert(
+                                    "cli_version".to_string(),
+                                    RefOr::T(Schema::Object(Box::new(
+                                        Object::new().schema_type(SchemaType::String),
+                                    ))),
+                                );
+                                props.insert(
+                                    "spec_version".to_string(),
+                                    RefOr::T(Schema::Object(Box::new(
+                                        Object::new().schema_type(SchemaType::String),
+                                    ))),
+                                );
+                                props.insert(
+                                    "platform".to_string(),
+                                    RefOr::T(Schema::Object(Box::new(
+                                        Object::new().schema_type(SchemaType::String),
+                                    ))),
+                                );
+                                props.insert(
+                                    "commands".to_string(),
+                                    RefOr::T(Schema::Array(Array::new().items(RefOr::T(
+                                        Schema::Object(Box::new(
+                                            Object::new()
+                                                .schema_type(SchemaType::Object)
+                                                .properties({
+                                                    let mut cmd_props = BTreeMap::new();
+                                                    cmd_props.insert(
+                                                        "name".to_string(),
+                                                        RefOr::T(Schema::Object(Box::new(
+                                                            Object::new()
+                                                                .schema_type(SchemaType::String),
+                                                        ))),
+                                                    );
+                                                    cmd_props.insert(
+                                                        "description".to_string(),
+                                                        RefOr::T(Schema::Object(Box::new(
+                                                            Object::new()
+                                                                .schema_type(SchemaType::String),
+                                                        ))),
+                                                    );
+                                                    cmd_props
+                                                }),
+                                        )),
+                                    )))),
+                                );
+                                props
+                            }),
+                        ))))
+                        .example(serde_json::json!({
+                            "cli_version": "1.0.0",
+                            "spec_version": "1.0.0",
+                            "platform": "linux-amd64",
+                            "commands": [
+                                {
+                                    "name": "validate",
+                                    "description": "Validate CLI specification files"
+                                },
+                                {
+                                    "name": "generate",
+                                    "description": "Generate CLI code from specification"
+                                },
+                                {
+                                    "name": "lint",
+                                    "description": "Lint CLI specification files"
+                                }
+                            ]
+                        })),
+                );
+                content
+            }),
+    );
+    responses
+}
+
+/// Builds the '/validate' subcommand.
+fn build_validate_command() -> Command {
+    let mut extensions = BTreeMap::new();
+    extensions.insert(
+        "x-cli-category".to_string(),
+        serde_json::Value::String("validation".to_string()),
+    );
+    extensions.insert(
+        "x-performance".to_string(),
+        serde_json::Value::String("fast".to_string()),
+    );
+
+    Command::new()
+        .summary("Validate CLI specification")
+        .description("Validate a CLI specification file against the OpenCLI standard")
+        .operation_id("validateCommand")
+        .aliases(vec!["val".to_string(), "check".to_string()])
+        .tags(vec!["core".to_string()])
+        .extensions(extensions)
+        .parameters(build_validate_command_parameters())
+        .responses(build_validate_command_responses())
+}
+
+/// Builds parameters for the validate command.
+fn build_validate_command_parameters() -> Vec<Parameter> {
+    let mut file_extensions = BTreeMap::new();
+    file_extensions.insert(
+        "x-completion".to_string(),
+        serde_json::Value::String("file".to_string()),
+    );
+    file_extensions.insert(
+        "x-validation".to_string(),
+        serde_json::Value::String("file-exists".to_string()),
+    );
+
+    vec![
+        Parameter::new_argument("file", 1)
+            .description("Path to the CLI specification file")
+            .required(true)
+            .scope(ParameterScope::Local)
+            .extensions(file_extensions)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .format(SchemaFormat::Path)
+                    .example(serde_json::Value::String("opencli.yaml".to_string())),
+            )))),
+        Parameter::new_flag("strict")
+            .alias(vec!["s".to_string()])
+            .description("Enable strict validation mode")
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::Boolean)
+                    .default_value(serde_json::Value::Bool(false)),
+            )))),
+        Parameter::new("output")
+            .alias(vec!["o".to_string()])
+            .description("Output format for validation results")
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .enum_values(vec![
+                        serde_json::Value::String("json".to_string()),
+                        serde_json::Value::String("yaml".to_string()),
+                        serde_json::Value::String("text".to_string()),
+                    ])
+                    .default_value(serde_json::Value::String("text".to_string())),
+            )))),
+    ]
+}
+
+/// Builds responses for the validate command.
+fn build_validate_command_responses() -> BTreeMap<String, Response> {
+    let mut responses = BTreeMap::new();
+    responses.insert(
+        "0".to_string(),
+        Response::new()
+            .description("Validation successful")
+            .content({
+                let mut content = BTreeMap::new();
+                content.insert(
+                    "text/plain".to_string(),
+                    MediaType::new().example(serde_json::Value::String(
+                        "✓ Validation successful\nNo errors found in opencli.yaml\n".to_string(),
+                    )),
+                );
+                content.insert(
+                    "application/json".to_string(),
+                    MediaType::new()
+                        .schema(RefOr::T(Schema::Object(Box::new(
+                            Object::new().schema_type(SchemaType::Object).properties({
+                                let mut props = BTreeMap::new();
+                                props.insert(
+                                    "valid".to_string(),
+                                    RefOr::T(Schema::Object(Box::new(
+                                        Object::new().schema_type(SchemaType::Boolean),
+                                    ))),
+                                );
+                                props.insert(
+                                    "file".to_string(),
+                                    RefOr::T(Schema::Object(Box::new(
+                                        Object::new().schema_type(SchemaType::String),
+                                    ))),
+                                );
+                                props.insert(
+                                    "errors".to_string(),
+                                    RefOr::T(Schema::Array(Array::new().items(RefOr::T(
+                                        Schema::Object(Box::new(
+                                            Object::new().schema_type(SchemaType::String),
+                                        )),
+                                    )))),
+                                );
+                                props.insert(
+                                    "warnings".to_string(),
+                                    RefOr::T(Schema::Array(Array::new().items(RefOr::T(
+                                        Schema::Object(Box::new(
+                                            Object::new().schema_type(SchemaType::String),
+                                        )),
+                                    )))),
+                                );
+                                props
+                            }),
+                        ))))
+                        .example(serde_json::json!({
+                            "valid": true,
+                            "file": "opencli.yaml",
+                            "errors": [],
+                            "warnings": []
+                        })),
+                );
+                content.insert(
+                    "application/yaml".to_string(),
+                    MediaType::new().example(serde_json::Value::String(
+                        "valid: true\nfile: opencli.yaml\nerrors: []\nwarnings: []\n".to_string(),
+                    )),
+                );
+                content
+            }),
+    );
+    responses.insert(
+        "1".to_string(),
+        Response::new().description("Validation failed").content({
+            let mut content = BTreeMap::new();
+            content.insert(
+                "text/plain".to_string(),
+                MediaType::new().example(serde_json::Value::String(
+                    "✗ Validation failed\nFound 2 errors in opencli.yaml:\n  - Line 5: Missing required field 'operationId'\n  - Line 12: Invalid enum value 'invalid-type'\n".to_string(),
+                )),
+            );
+            content.insert(
+                "application/json".to_string(),
+                MediaType::new()
+                    .schema(RefOr::Ref(Ref {
+                        ref_path: "#/components/schemas/ValidationResult".to_string(),
+                    }))
+                    .example(serde_json::json!({
+                        "valid": false,
+                        "file": "opencli.yaml",
+                        "errors": [
+                            {
+                                "line": 5,
+                                "message": "Missing required field 'operationId'",
+                                "severity": "error"
+                            },
+                            {
+                                "line": 12,
+                                "message": "Invalid enum value 'invalid-type'",
+                                "severity": "error"
+                            }
+                        ],
+                        "warnings": []
+                    })),
+            );
+            content
+        }),
+    );
+    responses.insert(
+        "2".to_string(),
+        Response::new()
+            .description("File not found or not readable")
+            .content({
+                let mut content = BTreeMap::new();
+                content.insert(
+                    "text/plain".to_string(),
+                    MediaType::new().example(serde_json::Value::String(
+                        "✗ Error: File not found\nCould not read 'missing-spec.yaml'\nPlease check the file path and permissions\n".to_string(),
+                    )),
+                );
+                content.insert(
+                    "application/json".to_string(),
+                    MediaType::new()
+                        .schema(RefOr::Ref(Ref {
+                            ref_path: "#/components/schemas/Error".to_string(),
+                        }))
+                        .example(serde_json::json!({
+                            "code": 2,
+                            "message": "File not found",
+                            "details": "Could not read 'missing-spec.yaml'"
+                        })),
+                );
+                content
+            }),
+    );
+    responses
+}
+
+/// Builds the '/generate' subcommand.
+fn build_generate_command() -> Command {
+    Command::new()
+        .summary("Generate CLI code")
+        .description("Generate CLI implementation code from specification")
+        .operation_id("generateCommand")
+        .aliases(vec!["gen".to_string(), "codegen".to_string()])
+        .tags(vec!["core".to_string()])
+        .parameters(build_generate_command_parameters())
+        .responses(build_generate_command_responses())
+}
+
+/// Builds parameters for the generate command.
+fn build_generate_command_parameters() -> Vec<Parameter> {
+    vec![
+        Parameter::new_argument("spec", 1)
+            .description("Path to the CLI specification file")
+            .required(true)
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .format(SchemaFormat::Path)
+                    .example(serde_json::Value::String("my-cli.yaml".to_string())),
+            )))),
+        Parameter::new("language")
+            .alias(vec!["l".to_string()])
+            .description("Target programming language")
+            .required(true)
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .enum_values(vec![
+                        serde_json::Value::String("go".to_string()),
+                        serde_json::Value::String("python".to_string()),
+                        serde_json::Value::String("javascript".to_string()),
+                        serde_json::Value::String("typescript".to_string()),
+                        serde_json::Value::String("rust".to_string()),
+                        serde_json::Value::String("java".to_string()),
+                    ])
+                    .example(serde_json::Value::String("go".to_string())),
+            )))),
+        Parameter::new("output-dir")
+            .alias(vec!["o".to_string()])
+            .description("Output directory for generated code")
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .format(SchemaFormat::Path)
+                    .default_value(serde_json::Value::String("./generated".to_string())),
+            )))),
+        Parameter::new("template")
+            .alias(vec!["t".to_string()])
+            .description("Code generation template")
+            .scope(ParameterScope::Local)
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .enum_values(vec![
+                        serde_json::Value::String("basic".to_string()),
+                        serde_json::Value::String("advanced".to_string()),
+                        serde_json::Value::String("framework".to_string()),
+                    ])
+                    .default_value(serde_json::Value::String("basic".to_string())),
+            )))),
+    ]
+}
+
+/// Builds responses for the generate command.
+fn build_generate_command_responses() -> BTreeMap<String, Response> {
+    let mut responses = BTreeMap::new();
+    responses.insert(
+        "0".to_string(),
+        Response::new()
+            .description("Code generation successful")
+            .content({
+                let mut content = BTreeMap::new();
+                content.insert(
+                    "text/plain".to_string(),
+                    MediaType::new().example(serde_json::Value::String(
+                        "✓ Code generation successful\nGenerated 5 files in ./generated:\n  - main.go\n  - cmd/root.go\n  - cmd/validate.go\n  - cmd/generate.go\n  - README.md\n".to_string(),
+                    )),
+                );
+                content.insert(
+                    "application/json".to_string(),
+                    MediaType::new()
+                        .schema(RefOr::Ref(Ref {
+                            ref_path: "#/components/schemas/GenerationResult".to_string(),
+                        }))
+                        .example(serde_json::json!({
+                            "success": true,
+                            "output_directory": "./generated",
+                            "language": "go",
+                            "template": "basic",
+                            "files_generated": [
+                                {
+                                    "path": "main.go",
+                                    "size": 1024,
+                                    "type": "source"
+                                },
+                                {
+                                    "path": "cmd/root.go",
+                                    "size": 2048,
+                                    "type": "source"
+                                },
+                                {
+                                    "path": "README.md",
+                                    "size": 512,
+                                    "type": "documentation"
+                                }
+                            ]
+                        })),
+                );
+                content
+            }),
+    );
+    responses.insert(
+        "1".to_string(),
+        Response::new().description("Generation failed").content({
+            let mut content = BTreeMap::new();
+            content.insert(
+                "text/plain".to_string(),
+                MediaType::new().example(serde_json::Value::String(
+                    "✗ Code generation failed\nError: Invalid specification file\nPlease run 'ocs validate' first\n".to_string(),
+                )),
+            );
+            content.insert(
+                "application/json".to_string(),
+                MediaType::new()
+                    .schema(RefOr::Ref(Ref {
+                        ref_path: "#/components/schemas/Error".to_string(),
+                    }))
+                    .example(serde_json::json!({
+                        "code": 1,
+                        "message": "Code generation failed",
+                        "details": "Invalid specification file. Please run validation first."
+                    })),
+            );
+            content
+        }),
+    );
+    responses
+}
+
+/// Builds the '/lint' subcommand.
+fn build_lint_command() -> Command {
+    Command::new()
+        .summary("Lint multiple CLI specification files")
+        .description("Check multiple CLI specification files for style and best practices")
+        .operation_id("lintCommand")
+        .aliases(vec!["check-style".to_string()])
+        .tags(vec!["core".to_string()])
+        .parameters(build_lint_command_parameters())
+        .responses(build_lint_command_responses())
+}
+
+/// Builds parameters for the lint command.
+fn build_lint_command_parameters() -> Vec<Parameter> {
+    vec![
+        Parameter::new_argument("files", 1)
+            .description("Paths to CLI specification files to lint")
+            .required(true)
+            .scope(ParameterScope::Local)
+            .arity(Arity::new().min(1))
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .format(SchemaFormat::Path)
+                    .example(serde_json::Value::String(
+                        "spec1.yaml spec2.yaml".to_string(),
+                    )),
+            )))),
+        Parameter::new("rules")
+            .alias(vec!["r".to_string()])
+            .description("Specific linting rules to apply")
+            .scope(ParameterScope::Local)
+            .arity(Arity::new().min(1).max(10))
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new()
+                    .schema_type(SchemaType::String)
+                    .example(serde_json::Value::String(
+                        "naming-convention parameter-validation".to_string(),
+                    )),
+            )))),
+        Parameter::new("exclude")
+            .alias(vec!["x".to_string()])
+            .description("Rules to exclude from linting")
+            .scope(ParameterScope::Local)
+            .arity(Arity::new().min(0).max(5))
+            .schema(RefOr::T(Schema::Object(Box::new(
+                Object::new().schema_type(SchemaType::String),
+            )))),
+    ]
+}
+
+/// Builds responses for the lint command.
+fn build_lint_command_responses() -> BTreeMap<String, Response> {
+    let mut responses = BTreeMap::new();
+    responses.insert(
+        "0".to_string(),
+        Response::new()
+            .description("Linting completed successfully")
+            .content({
+                let mut content = BTreeMap::new();
+                content.insert(
+                    "application/json".to_string(),
+                    MediaType::new().schema(RefOr::T(Schema::Object(Box::new(
+                        Object::new().schema_type(SchemaType::Object).properties({
+                            let mut props = BTreeMap::new();
+                            props.insert(
+                                "files_checked".to_string(),
+                                RefOr::T(Schema::Object(Box::new(
+                                    Object::new().schema_type(SchemaType::Integer),
+                                ))),
+                            );
+                            props.insert(
+                                "issues_found".to_string(),
+                                RefOr::T(Schema::Object(Box::new(
+                                    Object::new().schema_type(SchemaType::Integer),
+                                ))),
+                            );
+                            props.insert(
+                                "passed".to_string(),
+                                RefOr::T(Schema::Object(Box::new(
+                                    Object::new().schema_type(SchemaType::Boolean),
+                                ))),
+                            );
+                            props
+                        }),
+                    )))),
+                );
+                content
+            }),
+    );
+    responses
+}
+
+/// Validates that the given JSON value complies with the OpenCLI JSON schema.
+fn assert_is_schema_compliant(spec_json: &serde_json::Value) {
+    let schema_content = include_str!("assets/opencli.spec.json");
+    let schema_value = serde_json::from_str(schema_content).expect("should parse OpenCLI schema");
+    let schema = jsonschema::validator_for(&schema_value).expect("should compile JSON schema");
+
+    let errors: Vec<String> = schema
+        .iter_errors(spec_json)
+        .map(|err| format!("- {}: {}", err.instance_path, err))
+        .collect();
+    if !errors.is_empty() {
+        panic!(
+            "Generated OpenCLI spec does not comply with schema:\n{}",
+            errors.join("\n")
+        );
+    }
+}

--- a/tests/tests/snapshots/it_build_kitchen_sink__build_opencli_with_complete_spec_succeeds.snap
+++ b/tests/tests/snapshots/it_build_kitchen_sink__build_opencli_with_complete_spec_succeeds.snap
@@ -1,0 +1,700 @@
+---
+source: tests/tests/it_build_kitchen_sink.rs
+expression: json_output
+---
+{
+  "opencli": "1.0.0",
+  "info": {
+    "title": "Open Command-Line Interface Specification",
+    "description": "Standard for defining command-line interfaces",
+    "version": "1.0.0",
+    "contact": {
+      "name": "OpenCLI Working Group",
+      "url": "https://github.com/nrranjithnr/open-cli-specification"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+  "commands": {
+    "/generate": {
+      "summary": "Generate CLI code",
+      "description": "Generate CLI implementation code from specification",
+      "operationId": "generateCommand",
+      "aliases": [
+        "gen",
+        "codegen"
+      ],
+      "tags": [
+        "core"
+      ],
+      "parameters": [
+        {
+          "name": "spec",
+          "in": "argument",
+          "position": 1,
+          "description": "Path to the CLI specification file",
+          "required": true,
+          "scope": "local",
+          "schema": {
+            "type": "string",
+            "format": "path",
+            "example": "my-cli.yaml"
+          }
+        },
+        {
+          "name": "language",
+          "alias": [
+            "l"
+          ],
+          "description": "Target programming language",
+          "required": true,
+          "scope": "local",
+          "schema": {
+            "type": "string",
+            "enum": [
+              "go",
+              "python",
+              "javascript",
+              "typescript",
+              "rust",
+              "java"
+            ],
+            "example": "go"
+          }
+        },
+        {
+          "name": "output-dir",
+          "alias": [
+            "o"
+          ],
+          "description": "Output directory for generated code",
+          "scope": "local",
+          "schema": {
+            "type": "string",
+            "format": "path",
+            "default": "./generated"
+          }
+        },
+        {
+          "name": "template",
+          "alias": [
+            "t"
+          ],
+          "description": "Code generation template",
+          "scope": "local",
+          "schema": {
+            "type": "string",
+            "enum": [
+              "basic",
+              "advanced",
+              "framework"
+            ],
+            "default": "basic"
+          }
+        }
+      ],
+      "responses": {
+        "0": {
+          "description": "Code generation successful",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerationResult"
+              },
+              "example": {
+                "files_generated": [
+                  {
+                    "path": "main.go",
+                    "size": 1024,
+                    "type": "source"
+                  },
+                  {
+                    "path": "cmd/root.go",
+                    "size": 2048,
+                    "type": "source"
+                  },
+                  {
+                    "path": "README.md",
+                    "size": 512,
+                    "type": "documentation"
+                  }
+                ],
+                "language": "go",
+                "output_directory": "./generated",
+                "success": true,
+                "template": "basic"
+              }
+            },
+            "text/plain": {
+              "example": "✓ Code generation successful\nGenerated 5 files in ./generated:\n  - main.go\n  - cmd/root.go\n  - cmd/validate.go\n  - cmd/generate.go\n  - README.md\n"
+            }
+          }
+        },
+        "1": {
+          "description": "Generation failed",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              },
+              "example": {
+                "code": 1,
+                "details": "Invalid specification file. Please run validation first.",
+                "message": "Code generation failed"
+              }
+            },
+            "text/plain": {
+              "example": "✗ Code generation failed\nError: Invalid specification file\nPlease run 'ocs validate' first\n"
+            }
+          }
+        }
+      }
+    },
+    "/lint": {
+      "summary": "Lint multiple CLI specification files",
+      "description": "Check multiple CLI specification files for style and best practices",
+      "operationId": "lintCommand",
+      "aliases": [
+        "check-style"
+      ],
+      "tags": [
+        "core"
+      ],
+      "parameters": [
+        {
+          "name": "files",
+          "in": "argument",
+          "position": 1,
+          "description": "Paths to CLI specification files to lint",
+          "required": true,
+          "scope": "local",
+          "arity": {
+            "min": 1
+          },
+          "schema": {
+            "type": "string",
+            "format": "path",
+            "example": "spec1.yaml spec2.yaml"
+          }
+        },
+        {
+          "name": "rules",
+          "alias": [
+            "r"
+          ],
+          "description": "Specific linting rules to apply",
+          "scope": "local",
+          "arity": {
+            "min": 1,
+            "max": 10
+          },
+          "schema": {
+            "type": "string",
+            "example": "naming-convention parameter-validation"
+          }
+        },
+        {
+          "name": "exclude",
+          "alias": [
+            "x"
+          ],
+          "description": "Rules to exclude from linting",
+          "scope": "local",
+          "arity": {
+            "min": 0,
+            "max": 5
+          },
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "responses": {
+        "0": {
+          "description": "Linting completed successfully",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files_checked": {
+                    "type": "integer"
+                  },
+                  "issues_found": {
+                    "type": "integer"
+                  },
+                  "passed": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/validate": {
+      "summary": "Validate CLI specification",
+      "description": "Validate a CLI specification file against the OpenCLI standard",
+      "operationId": "validateCommand",
+      "aliases": [
+        "val",
+        "check"
+      ],
+      "tags": [
+        "core"
+      ],
+      "parameters": [
+        {
+          "name": "file",
+          "in": "argument",
+          "position": 1,
+          "description": "Path to the CLI specification file",
+          "required": true,
+          "scope": "local",
+          "schema": {
+            "type": "string",
+            "format": "path",
+            "example": "opencli.yaml"
+          },
+          "x-completion": "file",
+          "x-validation": "file-exists"
+        },
+        {
+          "name": "strict",
+          "in": "flag",
+          "alias": [
+            "s"
+          ],
+          "description": "Enable strict validation mode",
+          "scope": "local",
+          "schema": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        {
+          "name": "output",
+          "alias": [
+            "o"
+          ],
+          "description": "Output format for validation results",
+          "scope": "local",
+          "schema": {
+            "type": "string",
+            "enum": [
+              "json",
+              "yaml",
+              "text"
+            ],
+            "default": "text"
+          }
+        }
+      ],
+      "responses": {
+        "0": {
+          "description": "Validation successful",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "file": {
+                    "type": "string"
+                  },
+                  "valid": {
+                    "type": "boolean"
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "example": {
+                "errors": [],
+                "file": "opencli.yaml",
+                "valid": true,
+                "warnings": []
+              }
+            },
+            "application/yaml": {
+              "example": "valid: true\nfile: opencli.yaml\nerrors: []\nwarnings: []\n"
+            },
+            "text/plain": {
+              "example": "✓ Validation successful\nNo errors found in opencli.yaml\n"
+            }
+          }
+        },
+        "1": {
+          "description": "Validation failed",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidationResult"
+              },
+              "example": {
+                "errors": [
+                  {
+                    "line": 5,
+                    "message": "Missing required field 'operationId'",
+                    "severity": "error"
+                  },
+                  {
+                    "line": 12,
+                    "message": "Invalid enum value 'invalid-type'",
+                    "severity": "error"
+                  }
+                ],
+                "file": "opencli.yaml",
+                "valid": false,
+                "warnings": []
+              }
+            },
+            "text/plain": {
+              "example": "✗ Validation failed\nFound 2 errors in opencli.yaml:\n  - Line 5: Missing required field 'operationId'\n  - Line 12: Invalid enum value 'invalid-type'\n"
+            }
+          }
+        },
+        "2": {
+          "description": "File not found or not readable",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              },
+              "example": {
+                "code": 2,
+                "details": "Could not read 'missing-spec.yaml'",
+                "message": "File not found"
+              }
+            },
+            "text/plain": {
+              "example": "✗ Error: File not found\nCould not read 'missing-spec.yaml'\nPlease check the file path and permissions\n"
+            }
+          }
+        }
+      },
+      "x-cli-category": "validation",
+      "x-performance": "fast"
+    },
+    "ocs": {
+      "summary": "Open CLI Spec tool",
+      "description": "Main entry point for the Open CLI Specification tool",
+      "operationId": "rootCommand",
+      "aliases": [
+        "opencli"
+      ],
+      "tags": [
+        "core"
+      ],
+      "parameters": [
+        {
+          "name": "config",
+          "alias": [
+            "c"
+          ],
+          "description": "Path to configuration file",
+          "scope": "inherited",
+          "schema": {
+            "type": "string",
+            "format": "path",
+            "example": "~/.config/ocs/config.yaml"
+          }
+        },
+        {
+          "name": "verbose",
+          "in": "flag",
+          "alias": [
+            "v"
+          ],
+          "description": "Enable verbose output",
+          "scope": "inherited",
+          "schema": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        {
+          "name": "quiet",
+          "in": "flag",
+          "alias": [
+            "q"
+          ],
+          "description": "Suppress non-essential output",
+          "scope": "inherited",
+          "schema": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        {
+          "name": "version",
+          "in": "flag",
+          "alias": [
+            "V"
+          ],
+          "description": "Show CLI version",
+          "scope": "local",
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "help",
+          "in": "flag",
+          "alias": [
+            "h"
+          ],
+          "description": "Show help information",
+          "scope": "local",
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "responses": {
+        "0": {
+          "description": "Version information displayed",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "cli_version": {
+                    "type": "string"
+                  },
+                  "commands": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "platform": {
+                    "type": "string"
+                  },
+                  "spec_version": {
+                    "type": "string"
+                  }
+                }
+              },
+              "example": {
+                "cli_version": "1.0.0",
+                "commands": [
+                  {
+                    "description": "Validate CLI specification files",
+                    "name": "validate"
+                  },
+                  {
+                    "description": "Generate CLI code from specification",
+                    "name": "generate"
+                  },
+                  {
+                    "description": "Lint CLI specification files",
+                    "name": "lint"
+                  }
+                ],
+                "platform": "linux-amd64",
+                "spec_version": "1.0.0"
+              }
+            },
+            "text/plain": {
+              "example": "ocs v1.0.0\nOpenCLI Specification v1.0.0\nPlatform: linux-amd64\n\nUsage: ocs [command] [flags]\n\nAvailable Commands:\n  validate    Validate CLI specification files\n  generate    Generate CLI code from specification\n  lint        Lint CLI specification files\n  \nUse \"ocs [command] --help\" for more information about a command.\n"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "details": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      },
+      "GeneratedFile": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "type"
+        ]
+      },
+      "GenerationResult": {
+        "type": "object",
+        "properties": {
+          "files_generated": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneratedFile"
+            }
+          },
+          "language": {
+            "type": "string"
+          },
+          "output_directory": {
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "template": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "output_directory"
+        ]
+      },
+      "ValidationError": {
+        "type": "object",
+        "properties": {
+          "line": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "error",
+              "warning"
+            ]
+          }
+        },
+        "required": [
+          "line",
+          "message",
+          "severity"
+        ]
+      },
+      "ValidationResult": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          },
+          "file": {
+            "type": "string"
+          },
+          "valid": {
+            "type": "boolean"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "core",
+      "description": "Core commands and utilities"
+    },
+    {
+      "name": "data",
+      "description": "Data processing commands"
+    },
+    {
+      "name": "auth",
+      "description": "Authentication and user management"
+    },
+    {
+      "name": "system",
+      "description": "System-level commands and utilities"
+    }
+  ],
+  "platforms": [
+    {
+      "name": "linux",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "name": "darwin",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    },
+    {
+      "name": "windows",
+      "architectures": [
+        "amd64",
+        "arm64"
+      ]
+    }
+  ],
+  "environment": [
+    {
+      "name": "OCS_CONFIG_PATH",
+      "description": "Override default configuration file path"
+    },
+    {
+      "name": "OCS_VERBOSE",
+      "description": "Enable verbose output globally"
+    },
+    {
+      "name": "OCS_QUIET",
+      "description": "Suppress non-essential output globally"
+    }
+  ],
+  "externalDocs": {
+    "description": "Find out more about OpenCLI",
+    "url": "https://www.openclispec.org"
+  }
+}

--- a/tests/tests/snapshots/it_build_kitchen_sink__serialize_opencli_to_yaml_succeeds.snap
+++ b/tests/tests/snapshots/it_build_kitchen_sink__serialize_opencli_to_yaml_succeeds.snap
@@ -1,0 +1,489 @@
+---
+source: tests/tests/it_build_kitchen_sink.rs
+expression: yaml_output
+---
+opencli: 1.0.0
+info:
+  title: Open Command-Line Interface Specification
+  description: Standard for defining command-line interfaces
+  version: 1.0.0
+  contact:
+    name: OpenCLI Working Group
+    url: https://github.com/nrranjithnr/open-cli-specification
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+commands:
+  /generate:
+    summary: Generate CLI code
+    description: Generate CLI implementation code from specification
+    operationId: generateCommand
+    aliases:
+    - gen
+    - codegen
+    tags:
+    - core
+    parameters:
+    - name: spec
+      in: argument
+      position: 1
+      description: Path to the CLI specification file
+      required: true
+      scope: local
+      schema:
+        type: string
+        format: path
+        example: my-cli.yaml
+    - name: language
+      alias:
+      - l
+      description: Target programming language
+      required: true
+      scope: local
+      schema:
+        type: string
+        enum:
+        - go
+        - python
+        - javascript
+        - typescript
+        - rust
+        - java
+        example: go
+    - name: output-dir
+      alias:
+      - o
+      description: Output directory for generated code
+      scope: local
+      schema:
+        type: string
+        format: path
+        default: ./generated
+    - name: template
+      alias:
+      - t
+      description: Code generation template
+      scope: local
+      schema:
+        type: string
+        enum:
+        - basic
+        - advanced
+        - framework
+        default: basic
+    responses:
+      '0':
+        description: Code generation successful
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerationResult'
+            example:
+              files_generated:
+              - path: main.go
+                size: 1024
+                type: source
+              - path: cmd/root.go
+                size: 2048
+                type: source
+              - path: README.md
+                size: 512
+                type: documentation
+              language: go
+              output_directory: ./generated
+              success: true
+              template: basic
+          text/plain:
+            example: |
+              ✓ Code generation successful
+              Generated 5 files in ./generated:
+                - main.go
+                - cmd/root.go
+                - cmd/validate.go
+                - cmd/generate.go
+                - README.md
+      '1':
+        description: Generation failed
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Error'
+            example:
+              code: 1
+              details: Invalid specification file. Please run validation first.
+              message: Code generation failed
+          text/plain:
+            example: |
+              ✗ Code generation failed
+              Error: Invalid specification file
+              Please run 'ocs validate' first
+  /lint:
+    summary: Lint multiple CLI specification files
+    description: Check multiple CLI specification files for style and best practices
+    operationId: lintCommand
+    aliases:
+    - check-style
+    tags:
+    - core
+    parameters:
+    - name: files
+      in: argument
+      position: 1
+      description: Paths to CLI specification files to lint
+      required: true
+      scope: local
+      arity:
+        min: 1
+      schema:
+        type: string
+        format: path
+        example: spec1.yaml spec2.yaml
+    - name: rules
+      alias:
+      - r
+      description: Specific linting rules to apply
+      scope: local
+      arity:
+        min: 1
+        max: 10
+      schema:
+        type: string
+        example: naming-convention parameter-validation
+    - name: exclude
+      alias:
+      - x
+      description: Rules to exclude from linting
+      scope: local
+      arity:
+        min: 0
+        max: 5
+      schema:
+        type: string
+    responses:
+      '0':
+        description: Linting completed successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                files_checked:
+                  type: integer
+                issues_found:
+                  type: integer
+                passed:
+                  type: boolean
+  /validate:
+    summary: Validate CLI specification
+    description: Validate a CLI specification file against the OpenCLI standard
+    operationId: validateCommand
+    aliases:
+    - val
+    - check
+    tags:
+    - core
+    parameters:
+    - name: file
+      in: argument
+      position: 1
+      description: Path to the CLI specification file
+      required: true
+      scope: local
+      schema:
+        type: string
+        format: path
+        example: opencli.yaml
+      x-completion: file
+      x-validation: file-exists
+    - name: strict
+      in: flag
+      alias:
+      - s
+      description: Enable strict validation mode
+      scope: local
+      schema:
+        type: boolean
+        default: false
+    - name: output
+      alias:
+      - o
+      description: Output format for validation results
+      scope: local
+      schema:
+        type: string
+        enum:
+        - json
+        - yaml
+        - text
+        default: text
+    responses:
+      '0':
+        description: Validation successful
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                errors:
+                  type: array
+                  items:
+                    type: string
+                file:
+                  type: string
+                valid:
+                  type: boolean
+                warnings:
+                  type: array
+                  items:
+                    type: string
+            example:
+              errors: []
+              file: opencli.yaml
+              valid: true
+              warnings: []
+          application/yaml:
+            example: |
+              valid: true
+              file: opencli.yaml
+              errors: []
+              warnings: []
+          text/plain:
+            example: |
+              ✓ Validation successful
+              No errors found in opencli.yaml
+      '1':
+        description: Validation failed
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationResult'
+            example:
+              errors:
+              - line: 5
+                message: Missing required field 'operationId'
+                severity: error
+              - line: 12
+                message: Invalid enum value 'invalid-type'
+                severity: error
+              file: opencli.yaml
+              valid: false
+              warnings: []
+          text/plain:
+            example: |
+              ✗ Validation failed
+              Found 2 errors in opencli.yaml:
+                - Line 5: Missing required field 'operationId'
+                - Line 12: Invalid enum value 'invalid-type'
+      '2':
+        description: File not found or not readable
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Error'
+            example:
+              code: 2
+              details: Could not read 'missing-spec.yaml'
+              message: File not found
+          text/plain:
+            example: |
+              ✗ Error: File not found
+              Could not read 'missing-spec.yaml'
+              Please check the file path and permissions
+    x-cli-category: validation
+    x-performance: fast
+  ocs:
+    summary: Open CLI Spec tool
+    description: Main entry point for the Open CLI Specification tool
+    operationId: rootCommand
+    aliases:
+    - opencli
+    tags:
+    - core
+    parameters:
+    - name: config
+      alias:
+      - c
+      description: Path to configuration file
+      scope: inherited
+      schema:
+        type: string
+        format: path
+        example: ~/.config/ocs/config.yaml
+    - name: verbose
+      in: flag
+      alias:
+      - v
+      description: Enable verbose output
+      scope: inherited
+      schema:
+        type: boolean
+        default: false
+    - name: quiet
+      in: flag
+      alias:
+      - q
+      description: Suppress non-essential output
+      scope: inherited
+      schema:
+        type: boolean
+        default: false
+    - name: version
+      in: flag
+      alias:
+      - V
+      description: Show CLI version
+      scope: local
+      schema:
+        type: boolean
+    - name: help
+      in: flag
+      alias:
+      - h
+      description: Show help information
+      scope: local
+      schema:
+        type: boolean
+    responses:
+      '0':
+        description: Version information displayed
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cli_version:
+                  type: string
+                commands:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                platform:
+                  type: string
+                spec_version:
+                  type: string
+            example:
+              cli_version: 1.0.0
+              commands:
+              - description: Validate CLI specification files
+                name: validate
+              - description: Generate CLI code from specification
+                name: generate
+              - description: Lint CLI specification files
+                name: lint
+              platform: linux-amd64
+              spec_version: 1.0.0
+          text/plain:
+            example: "ocs v1.0.0\nOpenCLI Specification v1.0.0\nPlatform: linux-amd64\n\nUsage: ocs [command] [flags]\n\nAvailable Commands:\n  validate    Validate CLI specification files\n  generate    Generate CLI code from specification\n  lint        Lint CLI specification files\n  \nUse \"ocs [command] --help\" for more information about a command.\n"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        details:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message
+    GeneratedFile:
+      type: object
+      properties:
+        path:
+          type: string
+        size:
+          type: integer
+        type:
+          type: string
+      required:
+      - path
+      - type
+    GenerationResult:
+      type: object
+      properties:
+        files_generated:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeneratedFile'
+        language:
+          type: string
+        output_directory:
+          type: string
+        success:
+          type: boolean
+        template:
+          type: string
+      required:
+      - success
+      - output_directory
+    ValidationError:
+      type: object
+      properties:
+        line:
+          type: integer
+        message:
+          type: string
+        severity:
+          type: string
+          enum:
+          - error
+          - warning
+      required:
+      - line
+      - message
+      - severity
+    ValidationResult:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+        file:
+          type: string
+        valid:
+          type: boolean
+        warnings:
+          type: array
+          items:
+            type: string
+tags:
+- name: core
+  description: Core commands and utilities
+- name: data
+  description: Data processing commands
+- name: auth
+  description: Authentication and user management
+- name: system
+  description: System-level commands and utilities
+platforms:
+- name: linux
+  architectures:
+  - amd64
+  - arm64
+- name: darwin
+  architectures:
+  - amd64
+  - arm64
+- name: windows
+  architectures:
+  - amd64
+  - arm64
+environment:
+- name: OCS_CONFIG_PATH
+  description: Override default configuration file path
+- name: OCS_VERBOSE
+  description: Enable verbose output globally
+- name: OCS_QUIET
+  description: Suppress non-essential output globally
+externalDocs:
+  description: Find out more about OpenCLI
+  url: https://www.openclispec.org


### PR DESCRIPTION
Add comprehensive E2E tests validating the complete OpenCLI specification builder API with kitchen sink scenarios and snapshot-based output verification.

- Add `tests/` workspace crate with kitchen sink E2E tests
- Include JSON fixtures and `insta` snapshot tests for validation
- Enhance CI workflow with separated test stages and coverage reporting
- Add `nextest.toml` and update `justfile` with test commands