### PR TITLE
refactor(utocli-core): improve builder API ergonomics with flexible option types

### DIFF
--- a/crates/utocli-core/src/opencli.rs
+++ b/crates/utocli-core/src/opencli.rs
@@ -162,27 +162,27 @@ impl OpenCliBuilder {
     }
 
     /// Sets the components.
-    pub fn components(mut self, components: Option<Components>) -> Self {
-        crate::builder_macros::set_value!(self components components)
+    pub fn components(mut self, components: impl Into<Option<Components>>) -> Self {
+        crate::builder_macros::set_value!(self components components.into())
     }
 
     /// Sets the tags.
-    pub fn tags(mut self, tags: Option<Vec<Tag>>) -> Self {
-        crate::builder_macros::set_value!(self tags tags)
+    pub fn tags(mut self, tags: impl Into<Option<Vec<Tag>>>) -> Self {
+        crate::builder_macros::set_value!(self tags tags.into())
     }
 
     /// Sets the platforms.
-    pub fn platforms(mut self, platforms: Option<Vec<Platform>>) -> Self {
-        crate::builder_macros::set_value!(self platforms platforms)
+    pub fn platforms(mut self, platforms: impl Into<Option<Vec<Platform>>>) -> Self {
+        crate::builder_macros::set_value!(self platforms platforms.into())
     }
 
     /// Sets the environment variables.
-    pub fn environment(mut self, environment: Option<Vec<EnvironmentVariable>>) -> Self {
-        crate::builder_macros::set_value!(self environment environment)
+    pub fn environment(mut self, environment: impl Into<Option<Vec<EnvironmentVariable>>>) -> Self {
+        crate::builder_macros::set_value!(self environment environment.into())
     }
 
     /// Sets the external documentation.
-    pub fn external_docs(mut self, external_docs: Option<ExternalDocs>) -> Self {
-        crate::builder_macros::set_value!(self external_docs external_docs)
+    pub fn external_docs(mut self, external_docs: impl Into<Option<ExternalDocs>>) -> Self {
+        crate::builder_macros::set_value!(self external_docs external_docs.into())
     }
 }

--- a/tests/tests/it_builder_kitchen_sink.rs
+++ b/tests/tests/it_builder_kitchen_sink.rs
@@ -3,7 +3,11 @@
 //! This test suite builds a comprehensive OpenCLI specification using the builder API,
 //! based on the official OpenCLI specification example.
 
-use utocli::*;
+use utocli::opencli::{
+    Architecture, Arity, Array, Command, Commands, Components, Contact, EnvironmentVariable,
+    ExternalDocs, Info, License, Map, MediaType, Object, OpenCliBuilder, Parameter, ParameterScope,
+    Platform, PlatformName, Ref, RefOr, Response, Schema, SchemaFormat, SchemaType, Tag,
+};
 
 #[test]
 fn build_opencli_with_complete_spec_succeeds() {
@@ -17,13 +21,15 @@ fn build_opencli_with_complete_spec_succeeds() {
     let commands = build_commands();
 
     //* When
-    let opencli = OpenCli::new(info)
+    let opencli = OpenCliBuilder::new()
+        .info(info)
         .commands(commands)
         .components(components)
         .tags(tags)
         .platforms(platforms)
         .environment(environment)
-        .external_docs(external_docs);
+        .external_docs(external_docs)
+        .build();
     let json_output =
         serde_json::to_string_pretty(&opencli).expect("should serialize OpenCLI to JSON");
 
@@ -48,13 +54,15 @@ fn serialize_opencli_to_yaml_succeeds() {
     let commands = build_commands();
 
     //* When
-    let opencli = OpenCli::new(info)
+    let opencli = OpenCliBuilder::new()
+        .info(info)
         .commands(commands)
         .components(components)
         .tags(tags)
         .platforms(platforms)
         .environment(environment)
-        .external_docs(external_docs);
+        .external_docs(external_docs)
+        .build();
     let yaml_output = serde_norway::to_string(&opencli).expect("should serialize OpenCLI to YAML");
 
     //* Then


### PR DESCRIPTION
Enhanced the OpenCliBuilder to accept more flexible parameter types and updated tests to use the builder pattern consistently.

- Change `OpenCliBuilder` optional field setters to accept `impl Into<Option<T>>` instead of `Option<T>` directly
- Update kitchen sink tests to use `OpenCliBuilder` instead of `OpenCli::new()` constructor
- Add explicit `.build()` call to construct final `OpenCli` instances